### PR TITLE
Changing python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ else()
 endif()
 
 # Check for dependencies
-find_package(PythonLibs REQUIRED)
-find_package(PythonInterp REQUIRED)
+find_package(PythonLibs 2.7 REQUIRED)
+find_package(PythonInterp 2.7 REQUIRED)
 #find_package(Boost REQUIRED python)
 find_package(Eigen3 REQUIRED)
 find_package(HDF5 REQUIRED CXX)


### PR DESCRIPTION
CMake now just looks for Python2.7.  Ran a build, and it worked without any flags or additional tweaking.